### PR TITLE
OPS-9068: roll back requirements.txt changes 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ prison==0.1.2
 py-zabbix==1.1.3
 PyStaticConfiguration>=0.10.3
 python-dateutil>=2.6.0,<2.7.0
-python-magic-bin>=0.4.14
+python-magic>=0.4.15
 PyYAML>=5.1
 requests>=2.0.0
 stomp.py>=4.1.17


### PR DESCRIPTION
seems this is needed for mac only