### PR TITLE
OPS-11045 - Handle unrecoverable AttributeError in custom exception method

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1315,7 +1315,7 @@ class ElastAlerter(object):
         except Exception as e:
             self.handle_uncaught_exception(e, rule)
             """ After the exception has been handled, exit without raising an exception """
-            os._exit(0)
+            os._exit(1)
         else:
             old_starttime = pretty_ts(rule.get('original_starttime'), rule.get('use_local_time'))
             elastalert_logger.info("Ran %s from %s to %s: %s query hits (%s already seen), %s matches,"

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1314,6 +1314,8 @@ class ElastAlerter(object):
             self.handle_error("Error running rule %s: %s" % (rule['name'], e), {'rule': rule['name']})
         except Exception as e:
             self.handle_uncaught_exception(e, rule)
+            """ After the exception has been handled, exit without raising an exception """
+            os._exit(0)
         else:
             old_starttime = pretty_ts(rule.get('original_starttime'), rule.get('use_local_time'))
             elastalert_logger.info("Ran %s from %s to %s: %s query hits (%s already seen), %s matches,"
@@ -1986,9 +1988,8 @@ class ElastAlerter(object):
         self.writeback('elastalert_error', body)
 
     def handle_uncaught_exception(self, exception, rule):
-        """ Disables a rule and sends a notification. """
         logging.error(traceback.format_exc())
-        self.handle_error('Uncaught exception running rule %s: %s' % (rule['name'], exception), {'rule': rule['name']})
+        """ Disables a rule and sends a notification. """
         if self.disable_rules_on_error:
             self.rules = [running_rule for running_rule in self.rules if running_rule['name'] != rule['name']]
             self.disabled_rules.append(rule)
@@ -1996,6 +1997,11 @@ class ElastAlerter(object):
             elastalert_logger.info('Rule %s disabled', rule['name'])
         if self.notify_email:
             self.send_notification_email(exception=exception, rule=rule)
+        """ Catch AttributeError exception from 'handle_error' when writing traceback to ES and preserve it in traceback """
+        try:
+            self.handle_error('Uncaught exception running rule %s: %s' % (rule['name'], exception), {'rule': rule['name']})
+        except AttributeError:
+            logging.error(traceback.format_exc())
 
     def send_notification_email(self, text='', exception=None, rule=None, subject=None, rule_file=None):
         email_body = text


### PR DESCRIPTION
As described in [OPS-11045](https://wkdauto.atlassian.net/browse/OPS-11045) due to ELK client connectivity lost, Elastalert doesn't execute rules anymore, which is causing absence of ~~logs~~ alerts. 

After `n` unsuccessful connection retries, custom `handle_uncaught_exception` method is being called, which prints the traceback but doesn't exit. Appscheduler continues to call `handle_rule_execution`, trying to resolve the client, but client object is long ago gone from memory, causing `AttributeError` exception trough the `handle_uncaugh_exception` method, which handles, well, uncaught exceptions. 

As the `handle_uncaught_exception` is the last method invocation in single run, this throws following error (including traceback): 

```
Nov 18, 2020 @ 18:11:10.344 | Uncaught exception running rule Production - OOM Container Killed: 'NoneType' object has no attribute 'resolve_writeback_index'
Nov 18, 2020 @ 18:11:10.345 | Traceback (most recent call last):   File "/usr/local/lib/python3.6/site-packages/apscheduler/executors/base.py", line 125, in run_job     retval = job.func(*job.args, **job.kwargs)   File "/home/elastalert/elastalert/elastalert.py", line 1316, in handle_rule_execution     self.handle_uncaught_exception(e, rule)   File "/home/elastalert/elastalert/elastalert.py", line 1991, in handle_uncaught_exception     self.handle_error('Uncaught exception running rule %s: %s' % (rule['name'], exception), {'rule': rule['name']})   File "/home/elastalert/elastalert/elastalert.py", line 1986, in handle_error     self.writeback('elastalert_error', body)   File "/home/elastalert/elastalert/elastalert.py", line 1666, in writeback     index = self.writeback_es.resolve_writeback_index(self.writeback_index, doc_type)
```
[Kibana URL](https://kibana.prod.services.auto1.team/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2020-11-18T17:10:00.000Z',to:'2020-11-18T17:11:50.000Z'))&_a=(columns:!(message),filters:!(),index:'*beat-*',interval:auto,query:(language:kuery,query:'service.name:%20elastalert%20and%20not%20message:%20(%22query%20hits%22%20or%20%22Queried%20rule%22%20or%20%22Run%20time%20of%20job%22)%20and%20message:%20%22uncaught%22'),sort:!(!('@timestamp',asc))))

Proposed PR resolves this issue by wrapping the subsequent called method in `try...except` block within the `handle_uncaught_exception` and exiting in parent method call after the `uncaught_exception` has been handled. 

Desired behaviour can be reproduced only from within the execution context by deleting client attribute early in `handle_rule_execution` or creating a breakpoint and deleting object/method using pdb/ipdb.

Tested within the Docker (exiting): 
```
docker-elastalert    | INFO:elastalert:Starting up
docker-elastalert    | INFO:elastalert:Disabled rules are: []
docker-elastalert    | INFO:elastalert:Sleeping for 9.999857 seconds
docker-elastalert    | INFO:elastalert:Disabled rules are: []
docker-elastalert    | INFO:elastalert:Sleeping for 9.999458 seconds
docker-elastalert    | INFO:elastalert:Background configuration change check run at 2020-12-01 19:34:25 CET
docker-elastalert    | ERROR:apscheduler.executors.default:Job "ElastAlerter.handle_pending_alerts (trigger: interval[0:00:10], next run at: 2020-12-01 19:34:35 CET)" raised an exception
docker-elastalert    | Traceback (most recent call last):
docker-elastalert    |   File "/usr/local/lib/python3.6/site-packages/apscheduler/executors/base.py", line 125, in run_job
docker-elastalert    |     retval = job.func(*job.args, **job.kwargs)
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 1272, in handle_pending_alerts
docker-elastalert    |     self.send_pending_alerts()
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 1709, in send_pending_alerts
docker-elastalert    |     pending_alerts = self.find_recent_pending_alerts(self.alert_time_limit)
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 1698, in find_recent_pending_alerts
docker-elastalert    |     res = self.writeback_es.search(index=self.writeback_index, body=query, size=1000)
docker-elastalert    | AttributeError: 'ElastAlerter' object has no attribute 'writeback_index'
docker-elastalert    | ERROR:root:Traceback (most recent call last):
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 1314, in handle_rule_execution
docker-elastalert    |     num_matches = self.run_rule(rule, endtime, rule.get('initial_starttime'))
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 869, in run_rule
docker-elastalert    |     self.set_starttime(rule, endtime)
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 712, in set_starttime
docker-elastalert    |     last_run_end = self.get_starttime(rule)
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 684, in get_starttime
docker-elastalert    |     index = self.writeback_es.resolve_writeback_index(self.writeback_index, doc_type)
docker-elastalert    | AttributeError: 'ElastAlerter' object has no attribute 'writeback_index'
docker-elastalert    | 
docker-elastalert    | INFO:elastalert:Rule TEST_RULE disabled
docker-elastalert    | ERROR:root:Uncaught exception running rule TEST_RULE: 'ElastAlerter' object has no attribute 'writeback_index'
docker-elastalert    | ERROR:root:Traceback (most recent call last):
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 1314, in handle_rule_execution
docker-elastalert    |     num_matches = self.run_rule(rule, endtime, rule.get('initial_starttime'))
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 869, in run_rule
docker-elastalert    |     self.set_starttime(rule, endtime)
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 712, in set_starttime
docker-elastalert    |     last_run_end = self.get_starttime(rule)
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 684, in get_starttime
docker-elastalert    |     index = self.writeback_es.resolve_writeback_index(self.writeback_index, doc_type)
docker-elastalert    | AttributeError: 'ElastAlerter' object has no attribute 'writeback_index'
docker-elastalert    | 
docker-elastalert    | During handling of the above exception, another exception occurred:
docker-elastalert    | 
docker-elastalert    | Traceback (most recent call last):
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 2004, in handle_uncaught_exception
docker-elastalert    |     self.handle_error('Uncaught exception running rule %s: %s' % (rule['name'], exception), {'rule': rule['name']})
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 1990, in handle_error
docker-elastalert    |     self.writeback('elastalert_error', body)
docker-elastalert    |   File "/home/elastalert/elastalert/elastalert.py", line 1670, in writeback
docker-elastalert    |     index = self.writeback_es.resolve_writeback_index(self.writeback_index, doc_type)
docker-elastalert    | AttributeError: 'ElastAlerter' object has no attribute 'writeback_index'
docker-elastalert    | 
docker-elastalert exited with code 0
```